### PR TITLE
Add a vim function to return http response

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -66,6 +66,10 @@ Simple, huh? Header value will be in effect for all requests on any line after.
 In a response window status line you can see a response code and
 connect/read times. For example ``Response: 200 OK 42ms 10ms``.
 
+**NOTE:** if you use a status line plugin like lightline or airline, you will
+not see the response text in the status line. However, you can use
+``VialHttpResponse()`` to get the response or configure your plugin to show it.
+
 You can pass query params as usual::
 
     GET /query?q=some%3Astring+with+spaces&page=1

--- a/vial-plugin/vial_http/__init__.py
+++ b/vial-plugin/vial_http/__init__.py
@@ -5,3 +5,4 @@ def init():
     vial.register_command('VialHttp', '.plugin.http')
     vial.register_command('VialHttpBasicAuth', '.plugin.basic_auth_cmd', nargs='?')
     vial.register_function('VialHttpBasicAuth()', '.plugin.basic_auth_func')
+    vial.register_function('VialHttpResponse()', '.plugin.get_http_response')

--- a/vial-plugin/vial_http/multipart.py
+++ b/vial-plugin/vial_http/multipart.py
@@ -70,8 +70,8 @@ def encode_multipart(fields, files, boundary=None):
     body = b'\r\n'.join(lines)
 
     headers = {
-        b'Content-Type': b'multipart/form-data; boundary=%s' % boundary,
-        b'Content-Length': bstr(str(len(body))),
+        'Content-Type': b'multipart/form-data; boundary=%s' % boundary,
+        'Content-Length': bstr(str(len(body))),
     }
 
     return (body, headers)

--- a/vial-plugin/vial_http/plugin.py
+++ b/vial-plugin/vial_http/plugin.py
@@ -26,6 +26,18 @@ CONNECT_TIMEOUT = 5
 READ_TIMEOUT = 30
 XML_FORMAT_SIZE_THRESHOLD = 2 ** 20
 
+http_response = ''
+
+
+def set_http_response(response):
+    global http_response
+    http_response = response
+    return http_response;
+
+
+def get_http_response():
+    return http_response
+
 
 def sizeof_fmt(num, suffix='b'):
     for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
@@ -211,9 +223,10 @@ def http():
     content, ctype, jdata = format_content(rcontent_type, rctx.content)
 
     win, buf = make_scratch('__vial_http__')
-    win.options['statusline'] = 'Response: {} {} {}ms {}ms {}'.format(
+    response_text = 'Response: {} {} {}ms {}ms {}'.format(
         rctx.response.status, rctx.response.reason,
         rctx.ctime, rctx.rtime, sizeof_fmt(size))
+    win.options['statusline'] = set_http_response(response_text)
     vim.command('set filetype={}'.format(ctype))
     buf[:] = content.splitlines(False)
     win.cursor = 1, 0


### PR DESCRIPTION
Right now, http response is set to `statusline` directly. This makes statusline plugins like lightline and airline impossible to get the http response. Adding a vim function allows users to use it to set up their statusline plugins or get the http response on demand.